### PR TITLE
V4 access token via cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Requests to Googles API require authentication, which can be handled via [Google
 
 Also, make sure you request the right scopes from the user during authentication before using a client, as you will get unauthorized errors from Google (intended behaviour).
 
-# CONSTRUCTOR\_ARGS
+# CONSTRUCTOR ARGS
 
 ## cache
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@ Google::Client::Collection - Collection of modules to talk with Googles REST API
     use Google::Client::Collection;
 
     my $google = Google::Client::Collection->new(
-        access_token => 'XXXXX'
+        cache => CHI::Driver->new(), # ... or anything with a 'get($cache_key)' method
     );
+
+    # then before calling a google clients method, set the key to fetch the access_token from in the cache:
+    $google->set_cache_key('user-10-access-token');
 
     # eg: use a Google::Client::Files client:
     my $json = $google->files->list(); # lists all files available by calling: GET https://www.googleapis.com/drive/v3/files
@@ -16,15 +19,32 @@ Google::Client::Collection - Collection of modules to talk with Googles REST API
 # DESCRIPTION
 
 A compilation of Google::Client::\* clients used to connect to the many resources of [Googles REST API](https://developers.google.com/google-apps/products).
-All such clients can be found in CPAN under the 'Google::Client' namespace (eg Google::Client::Files).
-
-Sorry for the weird collection affix, Google::Client is taken :(.
+All such clients can be found in CPAN under the 'Google::Client' namespace (eg [Google::Client::Files](https://metacpan.org/pod/Google::Client::Files)).
+Each client uses the same constructor arguments, so they can be used separately if desired.
 
 You should only ever have to instantiate `Google::Client::Collection`, which will give you access to all the available REST clients (pull requests welcome to add more!).
 
 Requests to Googles API require authentication, which can be handled via [Google::OAuth2::Client::Simple](https://metacpan.org/pod/Google::OAuth2::Client::Simple).
 
-Also, make sure you request the right scopes from the user during authentication before using a client, as you will get unauthorized errors from Google (expected).
+Also, make sure you request the right scopes from the user during authentication before using a client, as you will get unauthorized errors from Google (intended behaviour).
+
+# CONSTRUCTOR\_ARGS
+
+## cache
+
+Required constructor argument. The cache can be any object
+that provides a `get($cache_key)` method to retrieve
+the access token. It'll be responsible for eventually
+expiring the access token so it's known when to
+request a new one.
+
+# METHODS
+
+## cache\_key
+
+The key to lookup the access token in the cache. Should be set
+before calling any method in a Google Client. It's a good
+idea to make this unique (per user maybe?).
 
 ## files
 
@@ -36,9 +56,14 @@ Ali Zia, `<ziali088@gmail.com>`
 
 # REPOSITORY
 
-https://github.com/ziali088/googleapi-client
+[https://github.com/ziali088/googleapi-client](https://github.com/ziali088/googleapi-client)
 
 # COPYRIGHT AND LICENSE
 
 This is free software. You may use it and distribute it under the same terms as Perl itself.
 Copyright (C) 2016 - Ali Zia
+
+# TODO
+
+- Catch known Google API errors instead of giving that responsibility to the user of module
+- Add more clients

--- a/dist.ini
+++ b/dist.ini
@@ -39,6 +39,7 @@ Moo = 0
 Moo::Role = 0
 
 [Prereqs / TestRequires]
+CHI = 0
 Class::Load = 0
 Path::Tiny = 0
 Test::Most = 0

--- a/lib/Google/Client/Collection.pm
+++ b/lib/Google/Client/Collection.pm
@@ -47,7 +47,7 @@ Requests to Googles API require authentication, which can be handled via L<Googl
 
 Also, make sure you request the right scopes from the user during authentication before using a client, as you will get unauthorized errors from Google (intended behaviour).
 
-=head1 CONSTRUCTOR_ARGS
+=head1 CONSTRUCTOR ARGS
 
 =head2 cache
 

--- a/lib/Google/Client/Role/Token.pm
+++ b/lib/Google/Client/Role/Token.pm
@@ -5,15 +5,42 @@ use warnings;
 
 use Moo::Role;
 
+has cache => (is => 'ro', required => 1);
+has cache_key => (is => 'rw', writer => 'set_cache_key');
+
 has access_token => (is => 'rw');
+
+around access_token => sub {
+    my ($orig, $self) = @_;
+    return undef unless $self->cache_key;
+    return $self->cache->get($self->cache_key);
+};
 
 =head1 NAME
 
 Google::Client::Role::Token
 
-=head2 DESCRIPTION
+=head1 DESCRIPTION
 
-A role that provides access token attrs/methods for Google::Client::* modules.
+A role that provides access token attrs/methods for Google::Client::* modules. Will get the
+access_token value keyed by C<< $self->cache_key >> from the cache.
+
+=head1 ATTRIBUTES
+
+=head2 access_token
+
+The access token retrieved from making an access token request to Google. Should only be used to get the value,
+as its value will be retrieved from the cache.
+
+=head2 cache
+
+The object which stores the access token. Can be a L<CHI|https://metacpan.org/pod/CHI> instance, or any object
+which provides a C<< get($key) >> method. Used to retrieve the access token.
+
+=head2 cache_key
+
+The key from which to get the access token from the cache. Should be set before making requests to Googles API
+as that's when we retrieve an access token.
 
 =head1 AUTHOR
 

--- a/t/02-request.t
+++ b/t/02-request.t
@@ -7,7 +7,11 @@ use Test::Most;
 use Test::Mock::Furl;
 use Furl::Response;
 
+use CHI;
+
 use Google::Client::Collection;
+
+my $chi = CHI->new(driver => 'Memory', global => 0);
 
 $Mock_furl->mock(
     request => sub {
@@ -19,14 +23,17 @@ $Mock_furl_res->mock(
     decoded_content => sub { return '{}'; }
 );
 
-ok my $client = Google::Client::Collection->new(), 'created client ok';
+ok my $client = Google::Client::Collection->new(
+    cache => $chi,
+    cache_key => 'test-key'
+), 'created client ok';
 
 throws_ok { $client->files->_request(
   method => 'GET',
   url => 'http://www.googleapis.com/some/test/path'
 ) } qr|access token not found or may have expired|, 'dies when no access token';
 
-ok $client->access_token('weaifgqirgjqpe'), 'test our file singleton can take on the base clients access token';
+$chi->set('test-key', 'test_access_token', 5);
 
 lives_ok { $client->files->_request(
     method => 'GET',

--- a/t/03-request-exceptions.t
+++ b/t/03-request-exceptions.t
@@ -9,7 +9,16 @@ use Furl::Response;
 
 use Google::Client::Collection;
 
-ok my $client = Google::Client::Collection->new(access_token => 'wefjwofjwiojfoaijfoafw'), 'created client ok';
+use CHI;
+
+my $chi = CHI->new(driver => 'Memory', global => 0);
+
+$chi->set('test-req', 'foobar', 5);
+
+ok my $client = Google::Client::Collection->new(
+    cache => $chi,
+    cache_key => 'test-req'
+), 'created client ok';
 
 {
     $Mock_furl->mock(

--- a/t/04-roles.t
+++ b/t/04-roles.t
@@ -3,6 +3,9 @@ use Test::Most;
 use Class::Load;
 use Path::Tiny;
 
+use CHI;
+my $chi = CHI->new(driver => 'Memory', global => 1);
+
 my @children = path("./lib/Google/Client")->children;
 
 foreach my $child ( @children ) {
@@ -12,7 +15,10 @@ foreach my $child ( @children ) {
     my $client = "Google::Client::".$basename;
     my ($class_loaded, $error) = Class::Load::try_load_class($client);
     ok $class_loaded, "loaded client: $client";
-    ok $client = $client->new(), 'instantiated client';
+    ok $client = $client->new(
+        cache => $chi,
+        cache_key => $basename . '-test-key'
+    ), 'instantiated client';
     foreach my $role (qw/Google::Client::Role::FurlAgent Google::Client::Role::Token/) {
         ok $client->does($role), "$client implements $role";
     }

--- a/t/files/00-api.t
+++ b/t/files/00-api.t
@@ -1,4 +1,5 @@
 use Test::Most;
+use CHI;
 
 use_ok('Google::Client::Files');
 can_ok(
@@ -20,7 +21,10 @@ can_ok(
 );
 
 use_ok('Google::Client::Collection');
-ok my $client = Google::Client::Collection->new(), 'ok built client';
+ok my $client = Google::Client::Collection->new(
+    cache => CHI->new(driver => 'Memory', global => 0),
+    cache_key => 'file-client'
+), 'ok built client';
 ok my $files = $client->files, 'got files client';
 is $files->base_url, 'https://www.googleapis.com/drive/v3/files', 'file client has correct base_url';
 

--- a/t/files/01-copy.t
+++ b/t/files/01-copy.t
@@ -1,14 +1,18 @@
 use Test::Most;
 use Test::Mock::Furl;
 use Furl::Response;
-use_ok('Google::Client::Collection');
-
+use CHI;
 use Path::Tiny;
+use Google::Client::Collection;
+
 my $content = path('./t/files/file-resource-object.json')->slurp;
 
+my $chi = CHI->new(driver => 'Memory', global => 0);
+$chi->set('file-client', 'test-access-token', 5);
 ok my $client = Google::Client::Collection->new(
-    access_token => 'bogey access token'
+    cache => $chi,
 ), 'ok built client';
+$client->set_cache_key('file-client');
 
 {
     $Mock_furl->mock(

--- a/t/files/02-create-media-files.t
+++ b/t/files/02-create-media-files.t
@@ -1,14 +1,18 @@
 use Test::Most;
 use Test::Mock::Furl;
 use Furl::Response;
-use_ok('Google::Client::Collection');
-
+use CHI;
 use Path::Tiny;
+use Google::Client::Collection;
+
 my $content = path('./t/files/file-resource-object.json')->slurp;
 
+my $chi = CHI->new(driver => 'Memory', global => 0);
+$chi->set('file-client', 'test-access-token', 5);
 ok my $client = Google::Client::Collection->new(
-    access_token => 'bogey access token'
+    cache => $chi,
 ), 'ok built client';
+$client->set_cache_key('file-client');
 
 {
     $Mock_furl->mock(

--- a/t/files/03-create.t
+++ b/t/files/03-create.t
@@ -1,14 +1,18 @@
 use Test::Most;
 use Test::Mock::Furl;
 use Furl::Response;
-use_ok('Google::Client::Collection');
-
+use CHI;
 use Path::Tiny;
+use Google::Client::Collection;
+
 my $content = path('./t/files/file-resource-object.json')->slurp;
 
+my $chi = CHI->new(driver => 'Memory', global => 0);
+$chi->set('file-client', 'test-access-token', 5);
 ok my $client = Google::Client::Collection->new(
-    access_token => 'bogey access token'
+    cache => $chi,
 ), 'ok built client';
+$client->set_cache_key('file-client');
 
 {
     $Mock_furl->mock(

--- a/t/files/04-delete.t
+++ b/t/files/04-delete.t
@@ -1,11 +1,15 @@
 use Test::Most;
 use Test::Mock::Furl;
 use Furl::Response;
-use_ok('Google::Client::Collection');
+use CHI;
+use Google::Client::Collection;
 
+my $chi = CHI->new(driver => 'Memory', global => 0);
+$chi->set('file-client', 'test-access-token', 5);
 ok my $client = Google::Client::Collection->new(
-    access_token => 'bogey access token'
+    cache => $chi,
 ), 'ok built client';
+$client->set_cache_key('file-client');
 
 {
     $Mock_furl->mock(

--- a/t/files/05-empty-trash.t
+++ b/t/files/05-empty-trash.t
@@ -1,11 +1,15 @@
 use Test::Most;
 use Test::Mock::Furl;
 use Furl::Response;
-use_ok('Google::Client::Collection');
+use CHI;
+use Google::Client::Collection;
 
+my $chi = CHI->new(driver => 'Memory', global => 0);
+$chi->set('file-client', 'test-access-token', 5);
 ok my $client = Google::Client::Collection->new(
-    access_token => 'bogey access token'
+    cache => $chi,
 ), 'ok built client';
+$client->set_cache_key('file-client');
 
 {
     $Mock_furl->mock(

--- a/t/files/06-export.t
+++ b/t/files/06-export.t
@@ -1,14 +1,18 @@
 use Test::Most;
 use Test::Mock::Furl;
 use Furl::Response;
-use_ok('Google::Client::Collection');
-
+use CHI;
 use Path::Tiny;
+use Google::Client::Collection;
+
 my $content = path('./t/files/file-resource-object.json')->slurp;
 
+my $chi = CHI->new(driver => 'Memory', global => 0);
+$chi->set('file-client', 'test-access-token', 5);
 ok my $client = Google::Client::Collection->new(
-    access_token => 'bogey access token'
+    cache => $chi,
 ), 'ok built client';
+$client->set_cache_key('file-client');
 
 {
     $Mock_furl->mock(

--- a/t/files/07-generate-ids.t
+++ b/t/files/07-generate-ids.t
@@ -1,13 +1,17 @@
 use Test::Most;
 use Test::Mock::Furl;
 use Furl::Response;
-use_ok('Google::Client::Collection');
+use CHI;
+use Google::Client::Collection;
 
 my $content = '{"kind": "drive#generateIds", "space": "testest", "ids": ["some", "string", "of", "ids"]}';
 
+my $chi = CHI->new(driver => 'Memory', global => 0);
+$chi->set('file-client', 'test-access-token', 5);
 ok my $client = Google::Client::Collection->new(
-    access_token => 'bogey access token'
+    cache => $chi,
 ), 'ok built client';
+$client->set_cache_key('file-client');
 
 {
     $Mock_furl->mock(

--- a/t/files/08-get.t
+++ b/t/files/08-get.t
@@ -1,14 +1,18 @@
 use Test::Most;
 use Test::Mock::Furl;
 use Furl::Response;
-use_ok('Google::Client::Collection');
-
+use CHI;
 use Path::Tiny;
+use Google::Client::Collection;
+
 my $content = path('./t/files/file-resource-object.json')->slurp;
 
+my $chi = CHI->new(driver => 'Memory', global => 0);
+$chi->set('file-client', 'test-access-token', 5);
 ok my $client = Google::Client::Collection->new(
-    access_token => 'bogey access token'
+    cache => $chi,
 ), 'ok built client';
+$client->set_cache_key('file-client');
 
 {
     $Mock_furl->mock(

--- a/t/files/09-list.t
+++ b/t/files/09-list.t
@@ -1,7 +1,8 @@
 use Test::Most;
 use Test::Mock::Furl;
 use Furl::Response;
-use_ok('Google::Client::Collection');
+use CHI;
+use Google::Client::Collection;
 
 my $content = '
 {
@@ -14,9 +15,12 @@ my $content = '
 }
 ';
 
+my $chi = CHI->new(driver => 'Memory', global => 0);
+$chi->set('file-client', 'test-access-token', 5);
 ok my $client = Google::Client::Collection->new(
-    access_token => 'bogey access token'
+    cache => $chi,
 ), 'ok built client';
+$client->set_cache_key('file-client');
 
 {
     $Mock_furl->mock(

--- a/t/files/10-update-media-files.t
+++ b/t/files/10-update-media-files.t
@@ -1,14 +1,18 @@
 use Test::Most;
 use Test::Mock::Furl;
 use Furl::Response;
-use_ok('Google::Client::Collection');
-
+use CHI;
 use Path::Tiny;
+use Google::Client::Collection;
+
 my $content = path('./t/files/file-resource-object.json')->slurp;
 
+my $chi = CHI->new(driver => 'Memory', global => 0);
+$chi->set('file-client', 'test-access-token', 5);
 ok my $client = Google::Client::Collection->new(
-    access_token => 'bogey access token'
+    cache => $chi,
 ), 'ok built client';
+$client->set_cache_key('file-client');
 
 {
     $Mock_furl->mock(

--- a/t/files/11-update.t
+++ b/t/files/11-update.t
@@ -1,14 +1,18 @@
 use Test::Most;
 use Test::Mock::Furl;
 use Furl::Response;
-use_ok('Google::Client::Collection');
-
+use CHI;
 use Path::Tiny;
+use Google::Client::Collection;
+
 my $content = path('./t/files/file-resource-object.json')->slurp;
 
+my $chi = CHI->new(driver => 'Memory', global => 0);
+$chi->set('file-client', 'test-access-token', 5);
 ok my $client = Google::Client::Collection->new(
-    access_token => 'bogey access token'
+    cache => $chi,
 ), 'ok built client';
+$client->set_cache_key('file-client');
 
 {
     $Mock_furl->mock(

--- a/t/files/12-watch.t
+++ b/t/files/12-watch.t
@@ -1,7 +1,8 @@
 use Test::Most;
 use Test::Mock::Furl;
 use Furl::Response;
-use_ok('Google::Client::Collection');
+use CHI;
+use Google::Client::Collection;
 
 my $content = '
 {
@@ -20,9 +21,12 @@ my $content = '
 }
 ';
 
+my $chi = CHI->new(driver => 'Memory', global => 0);
+$chi->set('file-client', 'test-access-token', 5);
 ok my $client = Google::Client::Collection->new(
-    access_token => 'bogey access token'
+    cache => $chi,
 ), 'ok built client';
+$client->set_cache_key('file-client');
 
 {
     $Mock_furl->mock(


### PR DESCRIPTION
This pull request makes it so access token fetching is done through a 'cache' like object instead of providing the access token directly on instantiation. The intent is to be able to create this client collection without having to first have an access token, and only retrieve it when making requests to Google
