### PR TITLE
return http content directly if its not json data we are expecting

### DIFF
--- a/lib/Google/Client/Files.pm
+++ b/lib/Google/Client/Files.pm
@@ -82,11 +82,11 @@ sub export {
     confess("No ID provided") unless ($id);
     confess("mimeType is a required param to export files") unless ($params->{mimeType});
     my $url = $self->_url("/$id/export", $params);
-    my $json = $self->_request(
+    my $decoded_content = $self->_request(
         method => 'GET',
         url => $url
     );
-    return $json;
+    return $decoded_content;
 }
 
 sub generate_ids {

--- a/lib/Google/Client/Role/FurlAgent.pm
+++ b/lib/Google/Client/Role/FurlAgent.pm
@@ -51,6 +51,11 @@ sub _request {
 
     return unless ( $response->decoded_content );
 
+    if ( $response->content_type !~ m/application\/json/ ) {
+        # not sure what it is, just return the content since it's successful
+        return $response->decoded_content;
+    }
+
     my $json = eval { decode_json($response->decoded_content); };
     confess("Error decoding JSON: $@") if $@;
 

--- a/t/02-request.t
+++ b/t/02-request.t
@@ -20,6 +20,10 @@ $Mock_furl->mock(
 );
 
 $Mock_furl_res->mock(
+    content_type => sub { return 'application/json'; }
+);
+
+$Mock_furl_res->mock(
     decoded_content => sub { return '{}'; }
 );
 

--- a/t/03-request-exceptions.t
+++ b/t/03-request-exceptions.t
@@ -23,23 +23,6 @@ ok my $client = Google::Client::Collection->new(
 {
     $Mock_furl->mock(
         request => sub {
-            return Furl::Response->new(1, 404, 'Not Found', {'content-type' => 'text/html'}, '<html><body>blah</body></html>');
-        }
-    );
-
-    $Mock_furl_res->mock(
-        decoded_content => sub { return '<html><body>blah</body></html>'; }
-    );
-
-    throws_ok { $client->files->_request(
-      method => 'GET',
-      url => 'http://www.googleapis.com/some/test/path'
-    ) } qr|error decoding json|i, 'dies if response is not correct json';
-}
-
-{
-    $Mock_furl->mock(
-        request => sub {
             return Furl::Response->new(1, '403', 'Forbidden', {'content-type' => 'application/json'}, '{"error": "bad token"}');
         }
     );

--- a/t/files/01-copy.t
+++ b/t/files/01-copy.t
@@ -22,6 +22,10 @@ $client->set_cache_key('file-client');
     );
 
     $Mock_furl_res->mock(
+        content_type => sub { return 'application/json'; }
+    );
+
+    $Mock_furl_res->mock(
         decoded_content => sub { return $content; }
     );
 

--- a/t/files/02-create-media-files.t
+++ b/t/files/02-create-media-files.t
@@ -22,6 +22,10 @@ $client->set_cache_key('file-client');
     );
 
     $Mock_furl_res->mock(
+        content_type => sub { return 'application/json'; }
+    );
+
+    $Mock_furl_res->mock(
         decoded_content => sub { return $content; }
     );
 

--- a/t/files/03-create.t
+++ b/t/files/03-create.t
@@ -22,6 +22,10 @@ $client->set_cache_key('file-client');
     );
 
     $Mock_furl_res->mock(
+        content_type => sub { return 'application/json'; }
+    );
+
+    $Mock_furl_res->mock(
         decoded_content => sub { return $content; }
     );
 

--- a/t/files/04-delete.t
+++ b/t/files/04-delete.t
@@ -19,6 +19,10 @@ $client->set_cache_key('file-client');
     );
 
     $Mock_furl_res->mock(
+        content_type => sub { return 'application/json'; }
+    );
+
+    $Mock_furl_res->mock(
         decoded_content => sub { return ''; }
     );
 

--- a/t/files/05-empty-trash.t
+++ b/t/files/05-empty-trash.t
@@ -19,6 +19,10 @@ $client->set_cache_key('file-client');
     );
 
     $Mock_furl_res->mock(
+        content_type => sub { return 'application/json'; }
+    );
+
+    $Mock_furl_res->mock(
         decoded_content => sub { return ''; }
     );
 

--- a/t/files/07-generate-ids.t
+++ b/t/files/07-generate-ids.t
@@ -21,6 +21,10 @@ $client->set_cache_key('file-client');
     );
 
     $Mock_furl_res->mock(
+        content_type => sub { return 'application/json'; }
+    );
+
+    $Mock_furl_res->mock(
         decoded_content => sub { return $content; }
     );
 

--- a/t/files/08-get.t
+++ b/t/files/08-get.t
@@ -22,6 +22,10 @@ $client->set_cache_key('file-client');
     );
 
     $Mock_furl_res->mock(
+        content_type => sub { return 'application/json'; }
+    );
+
+    $Mock_furl_res->mock(
         decoded_content => sub { return $content; }
     );
 

--- a/t/files/09-list.t
+++ b/t/files/09-list.t
@@ -30,6 +30,10 @@ $client->set_cache_key('file-client');
     );
 
     $Mock_furl_res->mock(
+        content_type => sub { return 'application/json'; }
+    );
+
+    $Mock_furl_res->mock(
         decoded_content => sub { return $content; }
     );
 

--- a/t/files/10-update-media-files.t
+++ b/t/files/10-update-media-files.t
@@ -22,6 +22,10 @@ $client->set_cache_key('file-client');
     );
 
     $Mock_furl_res->mock(
+        content_type => sub { return 'application/json'; }
+    );
+
+    $Mock_furl_res->mock(
         decoded_content => sub { return $content; }
     );
 

--- a/t/files/11-update.t
+++ b/t/files/11-update.t
@@ -22,6 +22,10 @@ $client->set_cache_key('file-client');
     );
 
     $Mock_furl_res->mock(
+        content_type => sub { return 'application/json'; }
+    );
+
+    $Mock_furl_res->mock(
         decoded_content => sub { return $content; }
     );
 

--- a/t/files/12-watch.t
+++ b/t/files/12-watch.t
@@ -36,6 +36,10 @@ $client->set_cache_key('file-client');
     );
 
     $Mock_furl_res->mock(
+        content_type => sub { return 'application/json'; }
+    );
+
+    $Mock_furl_res->mock(
         decoded_content => sub { return $content; }
     );
 


### PR DESCRIPTION
The 'export' method in Google returns the binary data of converting the file into the desired mimetype, so it's not json data that it's returning. I got confused by the documentation where it states for that method that it returns a Files resource.

This should hopefully return the data correctly, allowing you to store it as a file
